### PR TITLE
Enable 64bit `long double`

### DIFF
--- a/gcc/config/aarch64/aarch64-coff.h
+++ b/gcc/config/aarch64/aarch64-coff.h
@@ -31,7 +31,6 @@
 #undef PTRDIFF_TYPE
 #define PTRDIFF_TYPE	"long long int"
 
-#define TARGET_64BIT 1
 #define TARGET_LONG_DOUBLE_64 1
 
 #undef LONG_TYPE_SIZE

--- a/gcc/config/aarch64/aarch64-coff.h
+++ b/gcc/config/aarch64/aarch64-coff.h
@@ -37,8 +37,7 @@
 #undef LONG_TYPE_SIZE
 #define LONG_TYPE_SIZE 32
 
-#undef LONG_DOUBLE_TYPE_SIZE
-#define LONG_DOUBLE_TYPE_SIZE 64
+#define __NO_BINARY80__
 
 #define TARGET_SEH 1
 

--- a/gcc/config/aarch64/aarch64-coff.h
+++ b/gcc/config/aarch64/aarch64-coff.h
@@ -31,8 +31,14 @@
 #undef PTRDIFF_TYPE
 #define PTRDIFF_TYPE	"long long int"
 
+#define TARGET_64BIT 1
+#define TARGET_LONG_DOUBLE_64 1
+
 #undef LONG_TYPE_SIZE
 #define LONG_TYPE_SIZE 32
+
+#undef LONG_DOUBLE_TYPE_SIZE
+#define LONG_DOUBLE_TYPE_SIZE 64
 
 #define TARGET_SEH 1
 

--- a/gcc/config/aarch64/aarch64.cc
+++ b/gcc/config/aarch64/aarch64.cc
@@ -28855,6 +28855,14 @@ aarch64_scalar_mode_supported_p (scalar_mode mode)
   if (DECIMAL_FLOAT_MODE_P (mode))
     return default_decimal_float_supported_p ();
 
+/* If long double is 64bit, we need to explicitly specify that aarch64
+   port is prepared to handle TFmode instructions. If long double is
+   128bit, this is handled by default_scalar_mode_supported_p.  */
+#ifdef TARGET_LONG_DOUBLE_64
+  if (mode == TFmode)
+    return true;
+#endif
+
   return ((mode == HFmode || mode == BFmode)
 	  ? true
 	  : default_scalar_mode_supported_p (mode));

--- a/gcc/config/aarch64/aarch64.cc
+++ b/gcc/config/aarch64/aarch64.cc
@@ -28945,8 +28945,10 @@ aarch64_bitint_type_info (int n, struct bitint_info *info)
 static machine_mode
 aarch64_c_mode_for_floating_type (enum tree_index ti)
 {
+#ifndef TARGET_LONG_DOUBLE_64
   if (ti == TI_LONG_DOUBLE_TYPE)
     return TFmode;
+#endif
   return default_mode_for_floating_type (ti);
 }
 

--- a/libgfortran/configure
+++ b/libgfortran/configure
@@ -6225,10 +6225,12 @@ fi
 # or floating point numbers – or may want to reduce the libgfortran size
 # although they do have the support.
 LIBGOMP_CHECKED_INT_KINDS="1 2 4 8 16"
-LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16"
-
-
-
+case $host in
+  aarch64-*-mingw*)
+    LIBGOMP_CHECKED_REAL_KINDS="4 8" ;;
+  *)
+    LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16" ;;
+esac
 
 # Figure out whether the compiler supports "-ffunction-sections -fdata-sections",
 # similarly to how libstdc++ does it

--- a/libgfortran/configure
+++ b/libgfortran/configure
@@ -6226,7 +6226,7 @@ fi
 # although they do have the support.
 LIBGOMP_CHECKED_INT_KINDS="1 2 4 8 16"
 case $host in
-  aarch64-*-mingw*)
+  aarch64-*-mingw* | aarch64-*-cygwin*)
     LIBGOMP_CHECKED_REAL_KINDS="4 8" ;;
   *)
     LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16" ;;

--- a/libgfortran/configure.ac
+++ b/libgfortran/configure.ac
@@ -221,7 +221,7 @@ AM_CONDITIONAL(LIBGFOR_MINIMAL, false)
 # although they do have the support.
 LIBGOMP_CHECKED_INT_KINDS="1 2 4 8 16"
 case "${host}" in
-  aarch64-*-mingw*)
+  aarch64-*-mingw* | aarch64-*-cygwin*)
     LIBGOMP_CHECKED_REAL_KINDS="4 8" ;;
   *)
     LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16" ;;

--- a/libgfortran/configure.ac
+++ b/libgfortran/configure.ac
@@ -220,7 +220,12 @@ AM_CONDITIONAL(LIBGFOR_MINIMAL, false)
 # or floating point numbers – or may want to reduce the libgfortran size
 # although they do have the support.
 LIBGOMP_CHECKED_INT_KINDS="1 2 4 8 16"
-LIBGOMP_CHECKED_REAL_KINDS="4 8"
+case "${host}" in
+  aarch64-*-mingw*)
+    LIBGOMP_CHECKED_REAL_KINDS="4 8" ;;
+  *)
+    LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16" ;;
+esac
 
 AC_SUBST(LIBGOMP_CHECKED_INT_KINDS)
 AC_SUBST(LIBGOMP_CHECKED_REAL_KINDS)

--- a/libgfortran/configure.ac
+++ b/libgfortran/configure.ac
@@ -220,7 +220,7 @@ AM_CONDITIONAL(LIBGFOR_MINIMAL, false)
 # or floating point numbers – or may want to reduce the libgfortran size
 # although they do have the support.
 LIBGOMP_CHECKED_INT_KINDS="1 2 4 8 16"
-LIBGOMP_CHECKED_REAL_KINDS="4 8 10 16"
+LIBGOMP_CHECKED_REAL_KINDS="4 8"
 
 AC_SUBST(LIBGOMP_CHECKED_INT_KINDS)
 AC_SUBST(LIBGOMP_CHECKED_REAL_KINDS)


### PR DESCRIPTION
- I'd split enabling 64bit `long double` and enabling `_Float128` support into separate commits/PRs.
- If `long double` size is not 128bit, libgfortran requires having `_Float32`. For this reason, 10 and 16 byte `REAL` has been disabled in this PR until `_Float32` support will be added in the next PR.

Closes https://github.com/ZacWalk/mingw-woarm64-build/issues/9