### PR TITLE
Fix build on x86_64-pc-linux-gnu when host is aarch64-w64-mingw32

### DIFF
--- a/gcc/config.host
+++ b/gcc/config.host
@@ -127,6 +127,10 @@ case ${host} in
   i[34567]86-*-* \
   | x86_64-*-* )
     case ${target} in
+      aarch64*-*-*)
+	host_extra_gcc_objs="driver-aarch64.o"
+	host_xmake_file="${host_xmake_file} aarch64/x-aarch64"
+	;;
       i[34567]86-*-* \
       | x86_64-*-* )
 	host_extra_gcc_objs="driver-i386.o"


### PR DESCRIPTION
Fix build on `x86_64-pc-linux-gnu` when host and target is `aarch64-w64-mingw32`.

Without this change undefined reference to `host_detect_local_cpu` error occurs.