### PR TITLE
Fix undefined reference to `_Unwind_*` et al. when shared libgcc is built

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1285,7 +1285,7 @@ aarch64-*-mingw*)
 	d_target_objs="${d_target_objs} winnt-d.o"
 	target_has_targetcm="yes"
 	target_has_targetdm="yes"
-	tmake_file="${tmake_file} t-winnt mingw/t-cygming"
+	tmake_file="${tmake_file} t-winnt mingw/t-cygming t-slibgcc"
 	aarch64_multilibs="llp64"
 	case ${enable_threads} in
 	  "" | yes | win32)


### PR DESCRIPTION
Fixes:

```
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._GCC_specific_handler[.refptr._GCC_specific_handler]+0x0): undefined reference to `_GCC_specific_handler'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_SetIP[.refptr._Unwind_SetIP]+0x0): undefined reference to `_Unwind_SetIP'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_SetGR[.refptr._Unwind_SetGR]+0x0): undefined reference to `_Unwind_SetGR'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_GetIPInfo[.refptr._Unwind_GetIPInfo]+0x0): undefined reference to `_Unwind_GetIPInfo'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_GetLanguageSpecificData[.refptr._Unwind_GetLanguageSpecificData]+0x0): undefined reference to `_Unwind_GetLanguageSpecificData'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_GetRegionStart[.refptr._Unwind_GetRegionStart]+0x0): undefined reference to `_Unwind_GetRegionStart'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_GetDataRelBase[.refptr._Unwind_GetDataRelBase]+0x0): undefined reference to `_Unwind_GetDataRelBase'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_personality.o):(.rdata$.refptr._Unwind_GetTextRelBase[.refptr._Unwind_GetTextRelBase]+0x0): undefined reference to `_Unwind_GetTextRelBase'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_throw.o):(.rdata$.refptr._Unwind_Resume_or_Rethrow[.refptr._Unwind_Resume_or_Rethrow]+0x0): undefined reference to `_Unwind_Resume_or_Rethrow'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_ptr.o):(.rdata$.refptr._Unwind_RaiseException[.refptr._Unwind_RaiseException]+0x0): undefined reference to `_Unwind_RaiseException'
aarch64-w64-mingw32/bin/ld: .libs/compatibility.o:(.rdata$.refptr._Unwind_Resume[.refptr._Unwind_Resume]+0x0): undefined reference to `_Unwind_Resume'
aarch64-w64-mingw32/bin/ld: ../src/c++11/.libs/libc++11convenience.a(thread.o):(.rdata$.refptr.__gthr_win32_create[.refptr.__gthr_win32_create]+0x0): undefined reference to `__gthr_win32_create'
aarch64-w64-mingw32/bin/ld: ../src/c++11/.libs/libc++11convenience.a(thread.o):(.rdata$.refptr.__gthr_win32_join[.refptr.__gthr_win32_join]+0x0): undefined reference to `__gthr_win32_join'
aarch64-w64-mingw32/bin/ld: ../libsupc++/.libs/libsupc++convenience.a(eh_catch.o):(.rdata$.refptr._Unwind_DeleteException[.refptr._Unwind_DeleteException]+0x0): undefined reference to `_Unwind_DeleteException'
collect2: error: ld returned 1 exit status
```

when shared libgcc is enabled. The same config is included in `x86_64-w64-mingw32` target.

This fix is needed both for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115083 repro case and build of MinGW toolchain MSYS2 packages.

The PR is tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9389071274