### PR TITLE
Fix undefined references to `__gthr_win32_*` shared libgcc is built

### DIFF
--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -473,9 +473,9 @@ aarch64-*-mingw*)
 	else
 		tmake_dlldir_file="i386/t-dlldir-x"
 	fi
-	tmake_file="${tmake_file} ${tmake_thr_file} ${tmake_eh_file} ${tmake_dlldir_file}"
+	tmake_file="${tmake_file} ${tmake_eh_file} ${tmake_thr_file} ${tmake_dlldir_file}"
 	tmake_file="${tmake_file} t-dfprules"
-	tmake_file="${tmake_file} i386/t-slibgcc-cygming i386/t-cygming i386/t-mingw32"
+	tmake_file="${tmake_file} i386/t-slibgcc-cygming i386/t-slibgcc-mingw i386/t-cygming i386/t-mingw32"
 	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
 	tmake_file="${tmake_file} ${cpu_type}/t-lse t-slibgcc-libgcc"
 	tmake_file="${tmake_file} ${cpu_type}/t-softfp t-softfp t-crtfm"


### PR DESCRIPTION
This PR changes order of `${tmake_eh_file}` and `${tmake_thr_file}` files in thee target config as the `i386/t-seh-eh` overrides `LIB2ADDEH` variable while `mingw/t-gthr-win32` ads to it. Also it adds `i386/t-slibgcc-mingw` which includes `__gthr_win32_create/join` into shared libgcc exports. This fixes:

```
aarch64-w64-mingw32/bin/ld: ../src/c++11/.libs/libc++11convenience.a(thread.o):(.rdata$.refptr.__gthr_win32_create[.refptr.__gthr_win32_create]+0x0): undefined reference to `__gthr_win32_create'
aarch64-w64-mingw32/bin/ld: ../src/c++11/.libs/libc++11convenience.a(thread.o):(.rdata$.refptr.__gthr_win32_join[.refptr.__gthr_win32_join]+0x0): undefined reference to `__gthr_win32_join'
```

when building GCC with shared libgcc enabled. 

This fix is needed both for [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115083](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115083) repro case and build of MinGW toolchain MSYS2 packages.

Tested by https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build/actions/runs/9645452811 and https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9647377371