### PR TITLE
Add LTO support

### DIFF
--- a/gcc/config/aarch64/cygming.h
+++ b/gcc/config/aarch64/cygming.h
@@ -318,6 +318,15 @@ do {							\
 
 #define HAVE_64BIT_POINTERS 1
 
+extern void i386_pe_asm_lto_start (void);
+extern void i386_pe_asm_lto_end (void);
+
+/* Kludge because of missing PE-COFF support for early LTO debug.  */
+#undef  TARGET_ASM_LTO_START
+#define TARGET_ASM_LTO_START i386_pe_asm_lto_start
+#undef  TARGET_ASM_LTO_END
+#define TARGET_ASM_LTO_END i386_pe_asm_lto_end
+
 /* According to Windows x64 software convention, the maximum stack allocatable
    in the prologue is 4G - 8 bytes.  Furthermore, there is a limited set of
    instructions allowed to adjust the stack pointer in the epilog, forcing the

--- a/gcc/config/aarch64/cygming.h
+++ b/gcc/config/aarch64/cygming.h
@@ -318,14 +318,11 @@ do {							\
 
 #define HAVE_64BIT_POINTERS 1
 
-extern void i386_pe_asm_lto_start (void);
-extern void i386_pe_asm_lto_end (void);
-
 /* Kludge because of missing PE-COFF support for early LTO debug.  */
 #undef  TARGET_ASM_LTO_START
-#define TARGET_ASM_LTO_START i386_pe_asm_lto_start
+#define TARGET_ASM_LTO_START mingw_pe_asm_lto_start
 #undef  TARGET_ASM_LTO_END
-#define TARGET_ASM_LTO_END i386_pe_asm_lto_end
+#define TARGET_ASM_LTO_END mingw_pe_asm_lto_end
 
 /* According to Windows x64 software convention, the maximum stack allocatable
    in the prologue is 4G - 8 bytes.  Furthermore, there is a limited set of

--- a/gcc/config/i386/cygming.h
+++ b/gcc/config/i386/cygming.h
@@ -348,9 +348,9 @@ do {						\
 
 /* Kludge because of missing PE-COFF support for early LTO debug.  */
 #undef  TARGET_ASM_LTO_START
-#define TARGET_ASM_LTO_START i386_pe_asm_lto_start
+#define TARGET_ASM_LTO_START mingw_pe_asm_lto_start
 #undef  TARGET_ASM_LTO_END
-#define TARGET_ASM_LTO_END i386_pe_asm_lto_end
+#define TARGET_ASM_LTO_END mingw_pe_asm_lto_end
 
 #undef ASM_COMMENT_START
 #define ASM_COMMENT_START " #"

--- a/gcc/config/i386/i386-protos.h
+++ b/gcc/config/i386/i386-protos.h
@@ -315,8 +315,6 @@ extern void i386_pe_asm_output_aligned_decl_common (FILE *, tree,
 						    const char *,
 						    HOST_WIDE_INT,
 						    HOST_WIDE_INT);
-extern void i386_pe_asm_lto_start (void);
-extern void i386_pe_asm_lto_end (void);
 extern void i386_pe_start_function (FILE *, const char *, tree);
 extern void i386_pe_end_function (FILE *, const char *, tree);
 extern void i386_pe_end_cold_function (FILE *, const char *, tree);

--- a/gcc/config/mingw/winnt.cc
+++ b/gcc/config/mingw/winnt.cc
@@ -820,14 +820,14 @@ mingw_pe_file_end (void)
 static enum debug_info_levels saved_debug_info_level;
 
 void
-i386_pe_asm_lto_start (void)
+mingw_pe_asm_lto_start (void)
 {
   saved_debug_info_level = debug_info_level;
   debug_info_level = DINFO_LEVEL_NONE;
 }
 
 void
-i386_pe_asm_lto_end (void)
+mingw_pe_asm_lto_end (void)
 {
   debug_info_level = saved_debug_info_level;
 }

--- a/gcc/config/mingw/winnt.h
+++ b/gcc/config/mingw/winnt.h
@@ -23,6 +23,8 @@ http://www.gnu.org/licenses/.  */
 extern tree mingw_handle_selectany_attribute (tree *, tree, tree, int, bool *);
 
 extern void mingw_pe_asm_named_section (const char *, unsigned int, tree);
+extern void mingw_pe_asm_lto_start (void);
+extern void mingw_pe_asm_lto_end (void);
 extern void mingw_pe_declare_function_type (FILE *file, const char *name,
 	int pub);
 extern void mingw_pe_encode_section_info (tree, rtx, int);

--- a/libiberty/simple-object-coff.c
+++ b/libiberty/simple-object-coff.c
@@ -219,7 +219,9 @@ static const struct coff_magic_struct coff_magic[] =
   /* i386.  */
   { 0x14c, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL },
   /* x86_64.  */
-  { 0x8664, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL }
+  { 0x8664, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL },
+  /* AArch64.  */
+  { 0xaa64, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL }
 };
 
 /* See if we have a COFF file.  */


### PR DESCRIPTION
The patch reuse configuration for LTO from x64 and add aarch64 architecture to the list of supported COFF headers.
Renaming for i386_ functions will be done on the patch series preparation.

Validated with CI
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9879475395
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9888893952