### PR TITLE
Build configuration fixes to enable native `aarch64-w64-mingw32` build

### DIFF
--- a/fixincludes/configure
+++ b/fixincludes/configure
@@ -4818,8 +4818,7 @@ fi
 else
   case $host in
 	i?86-*-msdosdjgpp* | \
-	i?86-*-mingw32* | \
-	x86_64-*-mingw32* | \
+	*-*-mingw32* | \
 	*-*-beos* | \
         *-*-*vms*)
 		TARGET=twoprocess

--- a/fixincludes/configure.ac
+++ b/fixincludes/configure.ac
@@ -50,8 +50,7 @@ else
 fi],
 [case $host in
 	i?86-*-msdosdjgpp* | \
-	i?86-*-mingw32* | \
-	x86_64-*-mingw32* | \
+	*-*-mingw32* | \
 	*-*-beos* | \
         *-*-*vms*)
 		TARGET=twoprocess

--- a/gcc/config.build
+++ b/gcc/config.build
@@ -57,7 +57,7 @@ case $build in
     build_xm_file=i386/xm-cygwin.h
     build_exeext=.exe
     ;;
-  i[34567]86-*-mingw32* | x86_64-*-mingw*)
+  *-*-mingw*)
     build_xm_file=i386/xm-mingw32.h
     build_exeext=.exe
     t=`(CMD //c echo /c) 2>/dev/null`

--- a/gcc/config.host
+++ b/gcc/config.host
@@ -125,7 +125,8 @@ case ${host} in
     esac
     ;;
   i[34567]86-*-* \
-  | x86_64-*-* )
+  | x86_64-*-* \
+  | aarch64-*-*)
     case ${target} in
       aarch64*-*-*)
 	host_extra_gcc_objs="driver-aarch64.o"
@@ -234,7 +235,7 @@ case ${host} in
     host_exeext=.exe
     host_lto_plugin_soname=cyglto_plugin.dll
     ;;
-  i[34567]86-*-mingw32* | x86_64-*-mingw*)
+  *-*-mingw*)
     host_xm_file=i386/xm-mingw32.h
     host_xmake_file="${host_xmake_file} ${host_xmake_mingw} i386/x-mingw32"
     host_extra_gcc_objs="${host_extra_gcc_objs} ${host_extra_gcc_objs_mingw} driver-mingw32.o"
@@ -243,7 +244,7 @@ case ${host} in
     out_host_hook_obj=host-mingw32.o
     host_lto_plugin_soname=liblto_plugin.dll
     case ${host} in
-      x86_64-*-*)
+      x86_64-*-* | aarch64-*-*)
         use_long_long_for_widest_fast_int=yes
         ;;
     esac


### PR DESCRIPTION
These changes were needed to allow native `aarch64-w64-mingw32` toolchain build inside MSYS2 enviroment.

Tested by:

* https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10159307519
* https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10159304527