### PR TITLE
Large alignment support

### DIFF
--- a/gcc/config/aarch64/aarch64-coff.h
+++ b/gcc/config/aarch64/aarch64-coff.h
@@ -63,6 +63,16 @@
   assemble_name ((FILE), (NAME)),		\
   fprintf ((FILE), ",%u\n", (int)(ROUNDED)))
 
+#define ASM_OUTPUT_ALIGNED_LOCAL(FILE, NAME, SIZE, ALIGNMENT)  \
+  { \
+    unsigned HOST_WIDE_INT rounded = MAX((SIZE), 1); \
+    unsigned HOST_WIDE_INT alignment = MAX((ALIGNMENT), BIGGEST_ALIGNMENT); \
+    rounded += (alignment / BITS_PER_UNIT) - 1; \
+    rounded = (rounded / (alignment / BITS_PER_UNIT) \
+      * (alignment / BITS_PER_UNIT)); \
+    ASM_OUTPUT_LOCAL(FILE, NAME, SIZE, rounded); \
+  }
+
 #define ASM_OUTPUT_SKIP(STREAM, NBYTES) 	\
   fprintf (STREAM, "\t.space\t%d  // skip\n", (int) (NBYTES))
 


### PR DESCRIPTION
The patch handles alignment when it is bigger than BIGGEST_ALIGMENT.

Validated with CI
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10165888899