### PR TITLE
Fix C++ global static constructors not being called

### DIFF
--- a/gcc/config/aarch64/aarch64-coff.h
+++ b/gcc/config/aarch64/aarch64-coff.h
@@ -81,12 +81,6 @@
 #define ASM_OUTPUT_TYPE_DIRECTIVE(STREAM, NAME, TYPE)
 #define ASM_DECLARE_FUNCTION_SIZE(FILE, FNAME, DECL)
 
-#undef TARGET_ASM_CONSTRUCTOR
-#define TARGET_ASM_CONSTRUCTOR aarch64_elf_asm_constructor
-
-#undef TARGET_ASM_DESTRUCTOR
-#define TARGET_ASM_DESTRUCTOR aarch64_elf_asm_destructor
-
 #define TEXT_SECTION_ASM_OP	"\t.text"
 #define DATA_SECTION_ASM_OP	"\t.data"
 #define BSS_SECTION_ASM_OP	"\t.bss"
@@ -98,11 +92,6 @@
 
 #undef SUPPORTS_INIT_PRIORITY
 #define SUPPORTS_INIT_PRIORITY 0
-
-#undef CTORS_SECTION_ASM_OP
-#define CTORS_SECTION_ASM_OP "\t.section\t.init_array,\"aw\""
-#undef DTORS_SECTION_ASM_OP
-#define DTORS_SECTION_ASM_OP "\t.section\t.fini_array,\"aw\""
 
 // #undef STACK_CHECK_STATIC_BUILTIN
 // #define STACK_CHECK_STATIC_BUILTIN 1


### PR DESCRIPTION
Fixes the issue that C++ global static constructors were not called. It seems that the removed lines were mistakenly added during `woarm64` branch rebase on patch series 1.

There is a minor improvement of GCC tests results with this change applied comparing to `woarm64` branch but IMO that is bellow statistical error:

### Total summary `woarm64`
| Metric                | Count                 |
|-----------------------|-----------------------|
| Expected passes       | 573309      |
| Unexpected failures   | 224238  |
| Unexpected successes  | 172 |
| Expected failures     | 4522    |
| Unresolved testcases  | 7314 |
| Unsupported tests     | 11003    |
| DejaGnu errors        | 0       |
| Total                 | 820558                |
| Reliability rate      | 71%     |

vs.:

### Total summary `fix-static-constructor`
| Metric                | Count                 |
|-----------------------|-----------------------|
| Expected passes       | 573665      |
| Unexpected failures   | 224239  |
| Unexpected successes  | 172 |
| Expected failures     | 4523    |
| Unresolved testcases  | 7311 |
| Unsupported tests     | 11005    |
| DejaGnu errors        | 0       |
| Total                 | 820915                |
| Reliability rate      | 71%     |

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10555725454.