### PR TITLE
Allow some warnings when building libgcc

### DIFF
--- a/libgcc/config/aarch64/t-aarch64
+++ b/libgcc/config/aarch64/t-aarch64
@@ -30,4 +30,5 @@ LIB2ADDEH += \
 	$(srcdir)/config/aarch64/__arm_za_disable.S
 
 SHLIB_MAPFILES += $(srcdir)/config/aarch64/libgcc-sme.ver
-LIBGCC2_CFLAGS += -Werror -Wno-prio-ctor-dtor
+LIBGCC2_CFLAGS += -Werror -Wno-prio-ctor-dtor -Wno-error=attributes -Wno-error=unused-parameter \
+	-Wno-error=missing-prototypes -Wno-error=unused-function


### PR DESCRIPTION
Recent GCC commit https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/commit/71c7b446b98aa51294d79c45e37f1564668a1f3a added `-Werror` when building libgcc. This PR allows some warnings to pass the build. I suppose most of them will be fixed upstream soon except of https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/216.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/11446540006