### PR TITLE
Add support for shared attribute

### DIFF
--- a/gcc/config/aarch64/aarch64.cc
+++ b/gcc/config/aarch64/aarch64.cc
@@ -874,6 +874,7 @@ static const attribute_spec aarch64_gnu_attributes[] =
 #if TARGET_DLLIMPORT_DECL_ATTRIBUTES
   { "dllimport", 0, 0, false, false, false, false, handle_dll_attribute, NULL },
   { "dllexport", 0, 0, false, false, false, false, handle_dll_attribute, NULL },
+  { "shared",    0, 0, true,  false, false, false, mingw_handle_shared_attribute, NULL },
 #endif
 #ifdef SUBTARGET_ATTRIBUTE_TABLE
   SUBTARGET_ATTRIBUTE_TABLE

--- a/gcc/config/i386/i386-options.cc
+++ b/gcc/config/i386/i386-options.cc
@@ -4231,7 +4231,7 @@ static const attribute_spec ix86_gnu_attributes[] =
   { "dllexport", 0, 0, false, false, false, false, handle_dll_attribute,
     NULL },
   { "shared",    0, 0, true,  false, false, false,
-    ix86_handle_shared_attribute, NULL },
+    mingw_handle_shared_attribute, NULL },
 #endif
   { "ms_struct", 0, 0, false, false,  false, false,
     ix86_handle_struct_attribute, NULL },

--- a/gcc/config/i386/i386-protos.h
+++ b/gcc/config/i386/i386-protos.h
@@ -274,7 +274,6 @@ extern unsigned int ix86_local_alignment (tree, machine_mode,
 					  unsigned int, bool = false);
 extern unsigned int ix86_minimum_alignment (tree, machine_mode,
 					    unsigned int);
-extern tree ix86_handle_shared_attribute (tree *, tree, tree, int, bool *);
 extern int x86_field_alignment (tree, int);
 extern tree ix86_valid_target_attribute_tree (tree, tree,
 					      struct gcc_options *,

--- a/gcc/config/mingw/winnt.cc
+++ b/gcc/config/mingw/winnt.cc
@@ -55,8 +55,8 @@ along with GCC; see the file COPYING3.  If not see
 /* Handle a "shared" attribute;
    arguments as in struct attribute_spec.handler.  */
 tree
-ix86_handle_shared_attribute (tree *node, tree name, tree, int,
-			      bool *no_add_attrs)
+mingw_handle_shared_attribute (tree *node, tree name, tree, int,
+			       bool *no_add_attrs)
 {
   if (TREE_CODE (*node) != VAR_DECL)
     {

--- a/gcc/config/mingw/winnt.h
+++ b/gcc/config/mingw/winnt.h
@@ -21,6 +21,7 @@ http://www.gnu.org/licenses/.  */
 #ifndef USED_FOR_TARGET
 
 extern tree mingw_handle_selectany_attribute (tree *, tree, tree, int, bool *);
+extern tree mingw_handle_shared_attribute (tree *, tree, tree, int, bool *);
 
 extern void mingw_pe_asm_named_section (const char *, unsigned int, tree);
 extern void mingw_pe_asm_lto_start (void);


### PR DESCRIPTION
Cygwin uses shared secions, and gcc previously only recognized this attribute on x86